### PR TITLE
fix: Truncate timestamp precision to seconds for comparison

### DIFF
--- a/column.go
+++ b/column.go
@@ -26,7 +26,8 @@ func (c column) IsPrimaryKey() bool {
 func (c column) CastToText() string {
 	switch strings.ToLower(c.dataType) {
 	case "timestamp with time zone":
-		return fmt.Sprintf("extract(epoch from %s)::TEXT", c.name)
+		// Truncating the epoch means that timestamps will be compared "to the second"; timestamps with ms/ns differences will be considered equal.
+		return fmt.Sprintf("trunc(extract(epoch from %s)::NUMERIC)::TEXT", c.name)
 	default:
 		return c.name + "::TEXT"
 	}

--- a/verify_data_test.go
+++ b/verify_data_test.go
@@ -164,7 +164,7 @@ func TestVerifyData(t *testing.T) {
 		"jsonb": {`'{}'`, `'{"foo": ["bar", "baz"]}'`, `'{"foo": "bar"}'`, `'{"foo": "bar", "baz": "qux"}'`},
 
 		"date":                        {`'2020-12-31'`},
-		"timestamp with time zone":    {`'2020-12-31 23:59:59 -8:00'`}, // hashes differently for psql/crdb, convert to epoch when hashing
+		"timestamp with time zone":    {`'2020-12-31 23:59:59 -8:00'`, `'2022-06-08 20:03:06.957223+00'`}, // hashes differently for psql/crdb, convert to epoch when hashing
 		"timestamp without time zone": {`'2020-12-31 23:59:59'`},
 	}
 	keys := make([]string, len(columnTypes))


### PR DESCRIPTION
Small differences in db engine precision make it difficult to assert that two values are "equal". Ideally this change would truncate to `ms` precision, but at this point in time the Cockroach `trunc()` function doesn't accept the same `precision` parameter that the PostgreSQL `trunc()` implementation does.