### PR TITLE
Enable explicit include/exclude of column names [ 2864060333 ]

### DIFF
--- a/cmd/pgverify/cmd.go
+++ b/cmd/pgverify/cmd.go
@@ -13,17 +13,19 @@ import (
 
 // Flags
 var (
-	aliasesFlag, excludeSchemasFlag, excludeTablesFlag, includeSchemasFlag, includeTablesFlag, testModesFlag *[]string
-	logLevelFlag                                                                                             *string
-	bookendLimitFlag, sparseModFlag                                                                          *int
+	aliasesFlag, excludeSchemasFlag, excludeTablesFlag, includeSchemasFlag, includeTablesFlag, includeColumnsFlag, excludeColumnsFlag, testModesFlag *[]string
+	logLevelFlag                                                                                                                                     *string
+	bookendLimitFlag, sparseModFlag                                                                                                                  *int
 )
 
 func init() {
 	aliasesFlag = rootCmd.Flags().StringSlice("aliases", []string{}, "alias names for the supplied targets (comma separated)")
 	excludeSchemasFlag = rootCmd.Flags().StringSlice("exclude-schemas", []string{}, "schemas to skip verification, ignored if '--include-schemas' used (comma separated)")
 	excludeTablesFlag = rootCmd.Flags().StringSlice("exclude-tables", []string{}, "tables to skip verification, ignored if '--include-tables' used (comma separated)")
-	includeSchemasFlag = rootCmd.Flags().StringSlice("include-schemas", []string{}, "schemas to verify (comma separated)")
-	includeTablesFlag = rootCmd.Flags().StringSlice("include-tables", []string{}, "tables to verify (comma separated)")
+	excludeColumnsFlag = rootCmd.Flags().StringSlice("exclude-columns", []string{}, "column names to skip verification, ignored if '--include-columns' used (comma separated)")
+	includeSchemasFlag = rootCmd.Flags().StringSlice("include-schemas", []string{}, "schemas to verify (comma separated, defaults to all)")
+	includeTablesFlag = rootCmd.Flags().StringSlice("include-tables", []string{}, "tables to verify (comma separated, defaults to all)")
+	includeColumnsFlag = rootCmd.Flags().StringSlice("include-columns", []string{}, "columns to explicitly verify (comma separated, defaults to all)")
 
 	logLevelFlag = rootCmd.Flags().String("level", "info", "logging level")
 	testModesFlag = rootCmd.Flags().StringSliceP("tests", "t", []string{pgverify.TestModeFull},
@@ -56,6 +58,8 @@ var rootCmd = &cobra.Command{
 			pgverify.ExcludeTables(*excludeTablesFlag...),
 			pgverify.IncludeSchemas(*includeSchemasFlag...),
 			pgverify.ExcludeSchemas(*excludeSchemasFlag...),
+			pgverify.IncludeColumns(*includeColumnsFlag...),
+			pgverify.ExcludeColumns(*excludeColumnsFlag...),
 			pgverify.WithTests(*testModesFlag...),
 			pgverify.WithSparseMod(*sparseModFlag),
 			pgverify.WithBookendLimit(*bookendLimitFlag),

--- a/config.go
+++ b/config.go
@@ -35,6 +35,8 @@ type Config struct {
 	ExcludeTables  []string
 	IncludeSchemas []string
 	ExcludeSchemas []string
+	IncludeColumns []string
+	ExcludeColumns []string
 
 	// TestModes is a list of test modes to run, executed in order.
 	TestModes []string
@@ -126,6 +128,20 @@ func ExcludeTables(tables ...string) optionFunc {
 func IncludeTables(tables ...string) optionFunc {
 	return func(c *Config) {
 		c.IncludeTables = tables
+	}
+}
+
+// ExcludeColumns sets the exclude columns configuration.
+func ExcludeColumns(columns ...string) optionFunc {
+	return func(c *Config) {
+		c.ExcludeColumns = columns
+	}
+}
+
+// IncludeColumns sets the include columns configuration.
+func IncludeColumns(columns ...string) optionFunc {
+	return func(c *Config) {
+		c.IncludeColumns = columns
 	}
 }
 

--- a/verify_data_test.go
+++ b/verify_data_test.go
@@ -188,7 +188,7 @@ func TestVerifyData(t *testing.T) {
 	sort.Strings(sortedTypes)
 
 	tableNames := []string{"testtable1", "testtable2", "testtable3"}
-	createTableQueryBase := fmt.Sprintf("( id INT PRIMARY KEY, %s);", strings.Join(keysWithTypes, ", "))
+	createTableQueryBase := fmt.Sprintf("( id INT PRIMARY KEY, ignored TIMESTAMP WITH TIME ZONE DEFAULT NOW(), %s);", strings.Join(keysWithTypes, ", "))
 
 	rowCount := calculateRowCount(columnTypes)
 	insertDataQueryBase := `(id, ` + strings.Join(keys, ", ") + `) VALUES `
@@ -242,6 +242,7 @@ func TestVerifyData(t *testing.T) {
 			TestModeRowCount,
 		),
 		ExcludeSchemas("pg_catalog", "pg_extension", "information_schema", "crdb_internal"),
+		ExcludeColumns("ignored"),
 		WithAliases(aliases),
 	)
 	assert.NoError(t, err)


### PR DESCRIPTION
Recent investigations revealed that CockroachDB may be adding a `rowid` column under the hood - this feature allows us to ignore that column to verify the rest of a migration's data integrity.


[Monday item 2864060333](https://udacity.monday.com/boards/2593329990/pulses/2864060333)
Item 2864060333