### PR TITLE
 fix: ensure no duplicate columns in hash (2864060333)

### DIFF
--- a/column.go
+++ b/column.go
@@ -7,16 +7,18 @@ import (
 
 // column represents a column in a table.
 type column struct {
-	name       string
-	dataType   string
-	constraint string
+	name        string
+	dataType    string
+	constraints []string
 }
 
 // IsPrimaryKey attempts to parse the constraint string to determine if the
 // column is a primary key.
 func (c column) IsPrimaryKey() bool {
-	if c.constraint == "primary" || strings.HasSuffix(c.constraint, "_pkey") {
-		return true
+	for _, constraint := range c.constraints {
+		if constraint == "primary" || strings.HasSuffix(constraint, "_pkey") {
+			return true
+		}
 	}
 
 	return false

--- a/query_test.go
+++ b/query_test.go
@@ -35,7 +35,7 @@ func TestBuildFullHashQuery(t *testing.T) {
 
 		schemaName string
 		tableName  string
-		columns    []column
+		columns    map[string]column
 
 		expectedQuery string
 	}{
@@ -43,15 +43,15 @@ func TestBuildFullHashQuery(t *testing.T) {
 			name:       "happy path",
 			schemaName: "testSchema",
 			tableName:  "testTable",
-			columns: []column{
-				{name: "id", dataType: "uuid", constraints: []string{"this_is_a_pkey"}},
-				{name: "content", dataType: "text"},
-				{name: "when", dataType: "timestamp with time zone"},
+			columns: map[string]column{
+				"id":      {name: "id", dataType: "uuid", constraints: []string{"this_is_a_pkey", "another constraint"}},
+				"content": {name: "content", dataType: "text"},
+				"when":    {name: "when", dataType: "timestamp with time zone"},
 			},
 			expectedQuery: formatQuery(`
 				SELECT md5(string_agg(hash, ''))  
 				FROM 
-					(SELECT '' AS grouper, MD5(CONCAT(id::TEXT, content::TEXT, trunc(extract(epoch from when)::NUMERIC)::TEXT)) AS hash 
+					(SELECT '' AS grouper, MD5(CONCAT(content::TEXT, id::TEXT, trunc(extract(epoch from when)::NUMERIC)::TEXT)) AS hash 
 					FROM "testSchema"."testTable" ORDER BY 2)
 				AS eachrow  GROUP BY grouper`),
 		},

--- a/query_test.go
+++ b/query_test.go
@@ -44,7 +44,7 @@ func TestBuildFullHashQuery(t *testing.T) {
 			schemaName: "testSchema",
 			tableName:  "testTable",
 			columns: []column{
-				{name: "id", dataType: "uuid", constraint: "this_is_a_pkey"},
+				{name: "id", dataType: "uuid", constraints: []string{"this_is_a_pkey"}},
 				{name: "content", dataType: "text"},
 				{name: "when", dataType: "timestamp with time zone"},
 			},

--- a/verify.go
+++ b/verify.go
@@ -189,7 +189,7 @@ func (c Config) runTestQueriesOnTarget(ctx context.Context, logger *logrus.Entry
 				}
 
 				if c.validColumnTarget(columnName.String) {
-					tableColumns = append(tableColumns, column{columnName.String, dataType.String, constraintName.String})
+					tableColumns = append(tableColumns, column{columnName.String, dataType.String, []string{constraintName.String}})
 				}
 			}
 			tableLogger.Infof("Found %d columns", len(tableColumns))


### PR DESCRIPTION
The code had a bad implicit assumption for when it queried for column/constrain information, where columns with multiple constraints would be hashed multiple times together.