### PR TITLE
Configurable timestamp resolution

### DIFF
--- a/cmd/pgverify/cmd.go
+++ b/cmd/pgverify/cmd.go
@@ -14,7 +14,7 @@ import (
 // Flags.
 var (
 	aliasesFlag, excludeSchemasFlag, excludeTablesFlag, includeSchemasFlag, includeTablesFlag, includeColumnsFlag, excludeColumnsFlag, testModesFlag *[]string
-	logLevelFlag                                                                                                                                     *string
+	logLevelFlag, timestampPrecisionFlag                                                                                                             *string
 	bookendLimitFlag, sparseModFlag                                                                                                                  *int
 )
 
@@ -27,6 +27,7 @@ func init() {
 	includeTablesFlag = rootCmd.Flags().StringSlice("include-tables", []string{}, "tables to verify (comma separated, defaults to all)")
 	includeColumnsFlag = rootCmd.Flags().StringSlice("include-columns", []string{}, "columns to explicitly verify (comma separated, defaults to all)")
 
+	timestampPrecisionFlag = rootCmd.Flags().String("tz-precision", "milliseconds", "precision level to use when comparing timestamps")
 	logLevelFlag = rootCmd.Flags().String("level", "info", "logging level")
 	testModesFlag = rootCmd.Flags().StringSliceP("tests", "t", []string{pgverify.TestModeFull},
 		"tests to use for verification (comma separated, options: "+strings.Join([]string{
@@ -64,6 +65,7 @@ var rootCmd = &cobra.Command{
 			pgverify.WithTests(*testModesFlag...),
 			pgverify.WithSparseMod(*sparseModFlag),
 			pgverify.WithBookendLimit(*bookendLimitFlag),
+			pgverify.WithTimestampPrecision(*timestampPrecisionFlag),
 		}
 
 		logger := log.New()

--- a/column.go
+++ b/column.go
@@ -30,7 +30,7 @@ func (c column) CastToText() string {
 	switch strings.ToLower(c.dataType) {
 	case "timestamp with time zone":
 		// Truncating the epoch means that timestamps will be compared "to the second"; timestamps with ms/ns differences will be considered equal.
-		return fmt.Sprintf("trunc(extract(epoch from %s)::NUMERIC)::TEXT", c.name)
+		return fmt.Sprintf("extract(epoch from date_trunc('milliseconds', %s))::TEXT", c.name)
 	default:
 		return c.name + "::TEXT"
 	}

--- a/column.go
+++ b/column.go
@@ -26,11 +26,11 @@ func (c column) IsPrimaryKey() bool {
 
 // CastToText generates PSQL expression to cast the column to the TEXT type in
 // a way that is consistent between supported databases.
-func (c column) CastToText() string {
+func (c column) CastToText(precision string) string {
 	switch strings.ToLower(c.dataType) {
 	case "timestamp with time zone":
 		// Truncating the epoch means that timestamps will be compared "to the second"; timestamps with ms/ns differences will be considered equal.
-		return fmt.Sprintf("extract(epoch from date_trunc('milliseconds', %s))::TEXT", c.name)
+		return fmt.Sprintf("extract(epoch from date_trunc('%s', %s))::TEXT", precision, c.name)
 	default:
 		return c.name + "::TEXT"
 	}

--- a/config.go
+++ b/config.go
@@ -25,6 +25,8 @@ const (
 
 	// A rowcount test simply compares table row counts between targets.
 	TestModeRowCount = "rowcount"
+
+	TimestampPrecisionMilliseconds = "milliseconds"
 )
 
 // Config represents the configuration for running a verification.
@@ -51,6 +53,9 @@ type Config struct {
 	// supplied targets.
 	Aliases []string
 
+	// TimestampPrecision is the precision level to use when comparing timestamp values.
+	TimestampPrecision string
+
 	Logger *log.Logger
 }
 
@@ -74,6 +79,7 @@ func NewConfig(opts ...Option) Config {
 		WithTests(TestModeFull),
 		WithBookendLimit(TestModeBookendDefaultLimit),
 		WithSparseMod(TestModeSparseDefaultMod),
+		WithTimestampPrecision(TimestampPrecisionMilliseconds),
 	}
 
 	for _, opt := range append(defaultOpts, opts...) {
@@ -176,5 +182,14 @@ func WithSparseMod(mod int) optionFunc {
 func WithAliases(aliases []string) optionFunc {
 	return func(c *Config) {
 		c.Aliases = aliases
+	}
+}
+
+// WithTimestampPrecision sets the precision level to use when comparing
+// timestamp values. This can be useful for addressing precision differences
+// between engines, i.e. millisecond vs. microsecond.
+func WithTimestampPrecision(precision string) optionFunc {
+	return func(c *Config) {
+		c.TimestampPrecision = precision
 	}
 }

--- a/query.go
+++ b/query.go
@@ -94,10 +94,10 @@ func buildGetColumsQuery(schemaName, tableName string) string {
 
 // Constructs a query for test mode full that generates a MD5 hash of each row,
 // aggregates those hashes, and outputs a single hash of those hashes.
-func buildFullHashQuery(schemaName, tableName string, columns map[string]column) string {
+func buildFullHashQuery(config Config, schemaName, tableName string, columns map[string]column) string {
 	var columnsWithCasting []string
 	for _, column := range columns {
-		columnsWithCasting = append(columnsWithCasting, column.CastToText())
+		columnsWithCasting = append(columnsWithCasting, column.CastToText(config.TimestampPrecision))
 	}
 
 	sort.Strings(columnsWithCasting)
@@ -112,13 +112,13 @@ func buildFullHashQuery(schemaName, tableName string, columns map[string]column)
 // Similar to the full test query, this test differs by first selecting a subset
 // of the rows by casting the primary key value to an integer, then bucketing
 // based off of that value modulo the configured SparseMod value.
-func buildSparseHashQuery(schemaName, tableName string, columns map[string]column, sparseMod int) string {
+func buildSparseHashQuery(config Config, schemaName, tableName string, columns map[string]column, sparseMod int) string {
 	var columnsWithCasting []string
 
 	var primaryKey column
 
 	for _, column := range columns {
-		columnsWithCasting = append(columnsWithCasting, column.CastToText())
+		columnsWithCasting = append(columnsWithCasting, column.CastToText(config.TimestampPrecision))
 
 		if column.IsPrimaryKey() {
 			primaryKey = column
@@ -146,15 +146,15 @@ func buildSparseHashQuery(schemaName, tableName string, columns map[string]colum
 		primaryKey.name,
 		primaryKey.name,
 		schemaName, tableName,
-		primaryKey.CastToText(),
+		primaryKey.CastToText(config.TimestampPrecision),
 		sparseMod))
 }
 
 // Like the full test query, but only looks at the first and last N rows for generating hashes.
-func buildBookendHashQuery(schemaName, tableName string, columns map[string]column, limit int) string {
+func buildBookendHashQuery(config Config, schemaName, tableName string, columns map[string]column, limit int) string {
 	var columnsWithCasting []string
 	for _, column := range columns {
-		columnsWithCasting = append(columnsWithCasting, column.CastToText())
+		columnsWithCasting = append(columnsWithCasting, column.CastToText(config.TimestampPrecision))
 	}
 
 	sort.Strings(columnsWithCasting)

--- a/query_test.go
+++ b/query_test.go
@@ -51,7 +51,7 @@ func TestBuildFullHashQuery(t *testing.T) {
 			expectedQuery: formatQuery(`
 				SELECT md5(string_agg(hash, ''))  
 				FROM 
-					(SELECT '' AS grouper, MD5(CONCAT(content::TEXT, id::TEXT, trunc(extract(epoch from when)::NUMERIC)::TEXT)) AS hash 
+					(SELECT '' AS grouper, MD5(CONCAT(content::TEXT, extract(epoch from date_trunc('milliseconds', when))::TEXT, id::TEXT)) AS hash 
 					FROM "testSchema"."testTable" ORDER BY 2)
 				AS eachrow  GROUP BY grouper`),
 		},

--- a/query_test.go
+++ b/query_test.go
@@ -33,6 +33,7 @@ func TestBuildFullHashQuery(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 
+		config     Config
 		schemaName string
 		tableName  string
 		columns    map[string]column
@@ -41,6 +42,7 @@ func TestBuildFullHashQuery(t *testing.T) {
 	}{
 		{
 			name:       "happy path",
+			config:     Config{TimestampPrecision: TimestampPrecisionMilliseconds},
 			schemaName: "testSchema",
 			tableName:  "testTable",
 			columns: map[string]column{
@@ -57,7 +59,7 @@ func TestBuildFullHashQuery(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expectedQuery, buildFullHashQuery(tc.schemaName, tc.tableName, tc.columns))
+			require.Equal(t, tc.expectedQuery, buildFullHashQuery(tc.config, tc.schemaName, tc.tableName, tc.columns))
 		})
 	}
 }

--- a/verify.go
+++ b/verify.go
@@ -207,11 +207,11 @@ func (c Config) runTestQueriesOnTarget(ctx context.Context, logger *logrus.Entry
 
 				switch testMode {
 				case TestModeFull:
-					query = buildFullHashQuery(schemaName, tableName, tableColumns)
+					query = buildFullHashQuery(c, schemaName, tableName, tableColumns)
 				case TestModeBookend:
-					query = buildBookendHashQuery(schemaName, tableName, tableColumns, c.BookendLimit)
+					query = buildBookendHashQuery(c, schemaName, tableName, tableColumns, c.BookendLimit)
 				case TestModeSparse:
-					query = buildSparseHashQuery(schemaName, tableName, tableColumns, c.SparseMod)
+					query = buildSparseHashQuery(c, schemaName, tableName, tableColumns, c.SparseMod)
 				case TestModeRowCount:
 					query = buildRowCountQuery(schemaName, tableName)
 				}


### PR DESCRIPTION
Postgres and Cockroach have slightly different timestamp precision; previously in 0d54fa1efe20fcf7eeb51ae70a78834464e22b71 this was addressed indirectly by truncating a `numeric` casting, but this method allows for configurable time-terminology (i.e. `"years", "seconds", "milliseconds"`) to determine that precision. 