### PR TITLE
Rishmathur21/update ordering hash queries

### DIFF
--- a/query.go
+++ b/query.go
@@ -118,9 +118,9 @@ func buildFullHashQuery(config Config, schemaName, tableName string, columns []c
 
 	return formatQuery(fmt.Sprintf(`
 		SELECT md5(string_agg(hash, ''))
-		FROM (SELECT '' AS grouper, MD5(CONCAT(%s)) AS hash FROM "%s"."%s" ORDER BY CONCAT(%s)) AS eachrow
-		GROUP BY grouper
-		`, strings.Join(columnsWithCasting, ", "), schemaName, tableName, primaryColumnString))
+		FROM (SELECT '' AS grouper, MD5(CONCAT(%s)) AS hash, CONCAT(%s) as primary_key FROM "%s"."%s" ORDER BY CONCAT(%s)) AS eachrow
+		GROUP BY grouper, primary_key ORDER BY primary_key
+		`, strings.Join(columnsWithCasting, ", "), primaryColumnString, schemaName, tableName, primaryColumnString))
 }
 
 // Similar to the full test query, this test differs by first selecting a subset

--- a/query.go
+++ b/query.go
@@ -170,17 +170,20 @@ func buildSparseHashQuery(config Config, schemaName, tableName string, columns [
 
 	whenClausesString := strings.Join(whenClauses, " AND ")
 
+	primaryColumnString := strings.Join(primaryKeyNamesWithCasting, ", ")
+
 	return formatQuery(fmt.Sprintf(`
 		SELECT md5(string_agg(hash, ''))
 		FROM (
-			SELECT '' AS grouper, MD5(CONCAT(%s)) AS hash
+			SELECT '' AS grouper, MD5(CONCAT(%s)) AS hash, CONCAT(%s) as primary_key
 			FROM "%s"."%s"
 			WHERE %s
 			ORDER BY CONCAT(%s)
 		) AS eachrow
-		GROUP BY grouper
+		GROUP BY grouper, primary_key
+		ORDER BY primary_key
 		`,
-		strings.Join(columnsWithCasting, ", "),
+		strings.Join(columnsWithCasting, ", "), primaryColumnString,
 		schemaName, tableName, whenClausesString,
 		primaryKeyNamesWithCastingString))
 }

--- a/query.go
+++ b/query.go
@@ -118,9 +118,9 @@ func buildFullHashQuery(config Config, schemaName, tableName string, columns []c
 
 	return formatQuery(fmt.Sprintf(`
 		SELECT md5(string_agg(hash, ''))
-		FROM (SELECT '' AS grouper, MD5(CONCAT(%s)) AS hash, CONCAT(%s) as primary_key FROM "%s"."%s" ORDER BY CONCAT(%s)) AS eachrow
+		FROM (SELECT '' AS grouper, MD5(CONCAT(%s)) AS hash, CONCAT(%s) as primary_key FROM "%s"."%s") AS eachrow
 		GROUP BY grouper, primary_key ORDER BY primary_key
-		`, strings.Join(columnsWithCasting, ", "), primaryColumnString, schemaName, tableName, primaryColumnString))
+		`, strings.Join(columnsWithCasting, ", "), primaryColumnString, schemaName, tableName))
 }
 
 // Similar to the full test query, this test differs by first selecting a subset

--- a/query_test.go
+++ b/query_test.go
@@ -56,7 +56,7 @@ func TestBuildFullHashQuery(t *testing.T) {
             SELECT md5(string_agg(hash, ''))
             FROM
                 (SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash, CONCAT(id::TEXT) as primary_key
-                FROM "testSchema"."testTable" ORDER BY CONCAT(id::TEXT)) AS eachrow GROUP BY grouper, primary_key ORDER BY primary_key`),
+                FROM "testSchema"."testTable") AS eachrow GROUP BY grouper, primary_key ORDER BY primary_key`),
 		},
 		{
 			name:       "multi-column primary key",
@@ -73,7 +73,7 @@ func TestBuildFullHashQuery(t *testing.T) {
             SELECT md5(string_agg(hash, ''))
             FROM
                 (SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash, CONCAT(content::TEXT, id::TEXT) as primary_key
-                FROM "testSchema"."testTable" ORDER BY CONCAT(content::TEXT, id::TEXT)) AS eachrow GROUP BY grouper, primary_key ORDER BY primary_key`),
+                FROM "testSchema"."testTable") AS eachrow GROUP BY grouper, primary_key ORDER BY primary_key`),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/query_test.go
+++ b/query_test.go
@@ -55,8 +55,8 @@ func TestBuildFullHashQuery(t *testing.T) {
 			expectedQuery: formatQuery(`
             SELECT md5(string_agg(hash, ''))
             FROM
-                (SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash
-                FROM "testSchema"."testTable" ORDER BY CONCAT(id::TEXT)) AS eachrow GROUP BY grouper`),
+                (SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash, CONCAT(id::TEXT) as primary_key
+                FROM "testSchema"."testTable" ORDER BY CONCAT(id::TEXT)) AS eachrow GROUP BY grouper, primary_key ORDER BY primary_key`),
 		},
 		{
 			name:       "multi-column primary key",
@@ -72,8 +72,8 @@ func TestBuildFullHashQuery(t *testing.T) {
 			expectedQuery: formatQuery(`
             SELECT md5(string_agg(hash, ''))
             FROM
-                (SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash
-                FROM "testSchema"."testTable" ORDER BY CONCAT(content::TEXT, id::TEXT)) AS eachrow GROUP BY grouper`),
+                (SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash, CONCAT(content::TEXT, id::TEXT) as primary_key
+                FROM "testSchema"."testTable" ORDER BY CONCAT(content::TEXT, id::TEXT)) AS eachrow GROUP BY grouper, primary_key ORDER BY primary_key`),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/query_test.go
+++ b/query_test.go
@@ -105,14 +105,14 @@ func TestBuildSparseHashQuery(t *testing.T) {
 			expectedQuery: formatQuery(`
             SELECT md5(string_agg(hash, ''))
             FROM
-                ( SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash
+                ( SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash, CONCAT(id::TEXT) as primary_key
                 FROM "testSchema"."testTable" 
 				WHERE id in ( 
 					SELECT id FROM "testSchema"."testTable" 
 					WHERE ('x' || substr(md5(CONCAT(id::TEXT)),1,16))::bit(64)::bigint % 10 = 0 ) 
 					ORDER BY CONCAT(id::TEXT)
 				) 
-				AS eachrow GROUP BY grouper`),
+				AS eachrow GROUP BY grouper, primary_key ORDER BY primary_key`),
 		},
 		{
 			name:       "multi-column primary key",
@@ -127,7 +127,7 @@ func TestBuildSparseHashQuery(t *testing.T) {
 			expectedQuery: formatQuery(`
             SELECT md5(string_agg(hash, ''))
             FROM
-                ( SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash
+                ( SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash, CONCAT(content::TEXT, id::TEXT) as primary_key
                 FROM "testSchema"."testTable" 
 				WHERE content in ( 
 					SELECT content FROM "testSchema"."testTable" 
@@ -136,7 +136,7 @@ func TestBuildSparseHashQuery(t *testing.T) {
 					SELECT id FROM "testSchema"."testTable" 
 					WHERE ('x' || substr(md5(CONCAT(content::TEXT, id::TEXT)),1,16))::bit(64)::bigint % 10 = 0
 				) ORDER BY CONCAT(content::TEXT, id::TEXT) )
-				AS eachrow GROUP BY grouper`),
+				AS eachrow GROUP BY grouper, primary_key ORDER BY primary_key`),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
https://udacity.atlassian.net/browse/CORE-294

I think this fix resolves the issue of getting different ordering in CRDB and Postgres by bringing the ORDER BY out of the subquery.

Based on the documentation (https://www.cockroachlabs.com/docs/stable/order-by.html):

```
SELECT * FROM a, b ORDER BY a.x;                 -- valid, effective

SELECT * FROM (SELECT * FROM a ORDER BY a.x), b; -- ignored, ineffective
```