### PR TITLE
fix: Treat column type JSON as JSONB

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 linters:
   enable-all: true
   disable:
+    - typecheck
     - golint # deprecated
     - interfacer # deprecated
     - maligned # deprecated

--- a/column.go
+++ b/column.go
@@ -31,7 +31,7 @@ func (c column) CastToText(precision string) string {
 	case "timestamp with time zone":
 		// Truncating the epoch means that timestamps will be compared "to the second"; timestamps with ms/ns differences will be considered equal.
 		return fmt.Sprintf("(extract(epoch from date_trunc('%s', %s))::DECIMAL * 1000000)::BIGINT::TEXT", precision, c.name)
-	case "jsonb":
+	case "jsonb", "json":
 		return fmt.Sprintf("length(%s::TEXT)::TEXT", c.name)
 	default:
 		return c.name + "::TEXT"

--- a/integration_test.go
+++ b/integration_test.go
@@ -206,6 +206,7 @@ func TestVerifyData(t *testing.T) {
 		`character varying(64)`: {`'more string stuff'`},
 
 		"jsonb": {`'{}'`, `'{"foo": ["bar", "baz"]}'`, `'{"foo": "bar"}'`, `'{"foo": "bar", "baz": "qux"}'`, `'{"for sure?": true, "has numbers": 123.456, "this is": ["some", "json", "blob"]}'`},
+		"json":  {`'{}'`, `'{"foo": ["bar", "baz"]}'`, `'{"foo": "bar"}'`, `'{"foo": "bar", "baz": "qux"}'`, `'{"for sure?": true, "has numbers": 123.456, "this is": ["some", "json", "blob"]}'`},
 
 		"date":                        {`'2020-12-31'`},
 		"timestamp with time zone":    {`'2020-12-31 23:59:59 -8:00'`, `'2022-06-08 20:03:06.957223+00'`}, // hashes differently for psql/crdb, convert to epoch when hashing


### PR DESCRIPTION
Likely should have been caught in #18, this stems from a difference in postgres/cockrachdb key ordering that has been deemed 'not a bug': https://github.com/cockroachdb/cockroach/issues/96507