### PR TITLE
Fix ordering of text primary keys (PIE-1100)

### DIFF
--- a/cmd/pgverify/cmd.go
+++ b/cmd/pgverify/cmd.go
@@ -16,6 +16,7 @@ var (
 	aliasesFlag, excludeSchemasFlag, excludeTablesFlag, includeSchemasFlag, includeTablesFlag, includeColumnsFlag, excludeColumnsFlag, testModesFlag *[]string
 	logLevelFlag, timestampPrecisionFlag                                                                                                             *string
 	bookendLimitFlag, sparseModFlag                                                                                                                  *int
+	hashPrimaryKeysFlag                                                                                                                              *bool
 )
 
 func init() {
@@ -39,6 +40,8 @@ func init() {
 
 	bookendLimitFlag = rootCmd.Flags().Int("bookend-limit", pgverify.TestModeBookendDefaultLimit, "only check the first and last N rows (with --tests=bookend)")
 	sparseModFlag = rootCmd.Flags().Int("sparse-mod", pgverify.TestModeSparseDefaultMod, "only check every Nth row (with --tests=sparse)")
+
+	hashPrimaryKeysFlag = rootCmd.Flags().Bool("hash-primary-keys", false, "hash primary key values before comparing them (useful for TEXT primary keys)")
 }
 
 var rootCmd = &cobra.Command{
@@ -66,6 +69,10 @@ var rootCmd = &cobra.Command{
 			pgverify.WithSparseMod(*sparseModFlag),
 			pgverify.WithBookendLimit(*bookendLimitFlag),
 			pgverify.WithTimestampPrecision(*timestampPrecisionFlag),
+		}
+
+		if *hashPrimaryKeysFlag {
+			opts = append(opts, pgverify.WithHashPrimaryKeys())
 		}
 
 		logger := log.New()

--- a/config.go
+++ b/config.go
@@ -47,6 +47,11 @@ type Config struct {
 	// SparseMod is used in the sparse test mode to deterministically select a
 	// subset of rows, approximately 1/mod of the total.
 	SparseMod int
+	// HashPrimaryKeys is a flag that determines whether or not to hash the values
+	// of primary keys before using them for ordering. This is useful when the
+	// primary keys contain TEXT that is sorted differently between engines.
+	// May impact performance.
+	HashPrimaryKeys bool
 
 	// Aliases is a list of aliases to use for the target databases in reporting
 	// output. Is ignored if the number of aliases is not equal to the number of
@@ -191,5 +196,15 @@ func WithAliases(aliases []string) optionFunc {
 func WithTimestampPrecision(precision string) optionFunc {
 	return func(c *Config) {
 		c.TimestampPrecision = precision
+	}
+}
+
+// WithHashPrimaryKeys configures the verifier to hash primary keys before
+// ordering results. This is useful when the primary keys contain TEXT that is
+// sorted differently between engines.
+// May impact performance.
+func WithHashPrimaryKeys() optionFunc {
+	return func(c *Config) {
+		c.HashPrimaryKeys = true
 	}
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -324,6 +324,7 @@ func TestVerifyData(t *testing.T) {
 			pgverify.ExcludeColumns("ignored", "rowid"),
 			pgverify.WithAliases(aliases),
 			pgverify.WithBookendLimit(5),
+			pgverify.WithHashPrimaryKeys(),
 		)
 		require.NoError(t, err)
 		results.WriteAsTable(os.Stdout)

--- a/integration_test.go
+++ b/integration_test.go
@@ -232,7 +232,7 @@ func TestVerifyData(t *testing.T) {
 	sort.Strings(keysWithTypes)
 	sort.Strings(sortedTypes)
 
-	tableNames := []string{"testtable1", "testTABLE2", "testtable3"}
+	tableNames := []string{"testtable1", "testTABLE_multi_col_2", "testtable3"}
 	createTableQueryBase := fmt.Sprintf("( id INT DEFAULT 0 NOT NULL, zid INT DEFAULT 0 NOT NULL, ignored TIMESTAMP WITH TIME ZONE DEFAULT NOW(), %s);", strings.Join(keysWithTypes, ", "))
 
 	rowCount := calculateRowCount(columnTypes)
@@ -274,10 +274,16 @@ func TestVerifyData(t *testing.T) {
 			_, err = conn.Exec(ctx, createTableQuery)
 			require.NoError(t, err, "Failed to create table %s on %v with query: %s", tableName, db.image, createTableQuery)
 
-			pkeyString := fmt.Sprintf("single_col_pkey_%s PRIMARY KEY (id)", tableName)
-			if tableName == tableNames[1] {
+			var pkeyString string
+
+			switch {
+			case strings.Contains(tableName, "multi_col"):
 				pkeyString = fmt.Sprintf("multi_col_pkey_%s PRIMARY KEY (id, zid)", tableName)
+			default:
+				pkeyString = fmt.Sprintf("single_col_pkey_%s PRIMARY KEY (id)", tableName)
 			}
+
+			require.NotEmpty(t, pkeyString)
 
 			alterTableQuery := fmt.Sprintf(`ALTER TABLE ONLY "%s" ADD CONSTRAINT %s;`, tableName, pkeyString)
 			_, err = conn.Exec(ctx, alterTableQuery)

--- a/query.go
+++ b/query.go
@@ -116,11 +116,18 @@ func buildFullHashQuery(config Config, schemaName, tableName string, columns []c
 
 	primaryColumnString := strings.Join(primaryKeyNamesWithCasting, ", ")
 
+	primaryColumnConcatString := fmt.Sprintf("CONCAT(%s)", primaryColumnString)
+
+	hashPKeys := true
+	if hashPKeys {
+		primaryColumnConcatString = fmt.Sprintf("MD5(%s)", primaryColumnConcatString)
+	}
+
 	return formatQuery(fmt.Sprintf(`
 		SELECT md5(string_agg(hash, ''))
-		FROM (SELECT '' AS grouper, MD5(CONCAT(%s)) AS hash, CONCAT(%s) as primary_key FROM "%s"."%s") AS eachrow
+		FROM (SELECT '' AS grouper, MD5(CONCAT(%s)) AS hash, %s as primary_key FROM "%s"."%s") AS eachrow
 		GROUP BY grouper, primary_key ORDER BY primary_key
-		`, strings.Join(columnsWithCasting, ", "), primaryColumnString, schemaName, tableName))
+		`, strings.Join(columnsWithCasting, ", "), primaryColumnConcatString, schemaName, tableName))
 }
 
 // Similar to the full test query, this test differs by first selecting a subset
@@ -172,10 +179,17 @@ func buildSparseHashQuery(config Config, schemaName, tableName string, columns [
 
 	primaryColumnString := strings.Join(primaryKeyNamesWithCasting, ", ")
 
+	primaryColumnConcatString := fmt.Sprintf("CONCAT(%s)", primaryColumnString)
+
+	hashPKeys := true
+	if hashPKeys {
+		primaryColumnConcatString = fmt.Sprintf("MD5(%s)", primaryColumnConcatString)
+	}
+
 	return formatQuery(fmt.Sprintf(`
 		SELECT md5(string_agg(hash, ''))
 		FROM (
-			SELECT '' AS grouper, MD5(CONCAT(%s)) AS hash, CONCAT(%s) as primary_key
+			SELECT '' AS grouper, MD5(CONCAT(%s)) AS hash, %s as primary_key
 			FROM "%s"."%s"
 			WHERE %s
 			ORDER BY CONCAT(%s)
@@ -183,7 +197,7 @@ func buildSparseHashQuery(config Config, schemaName, tableName string, columns [
 		GROUP BY grouper, primary_key
 		ORDER BY primary_key
 		`,
-		strings.Join(columnsWithCasting, ", "), primaryColumnString,
+		strings.Join(columnsWithCasting, ", "), primaryColumnConcatString,
 		schemaName, tableName, whenClausesString,
 		primaryKeyNamesWithCastingString))
 }
@@ -209,6 +223,13 @@ func buildBookendHashQuery(config Config, schemaName, tableName string, columns 
 	allColumnsWithCasting := strings.Join(columnsWithCasting, ", ")
 	allPrimaryColumnsWithCasting := strings.Join(primaryKeyNamesWithCasting, ", ")
 
+	allPrimaryColumnsConcatString := fmt.Sprintf("CONCAT(%s)", allPrimaryColumnsWithCasting)
+
+	hashPKeys := true
+	if hashPKeys {
+		allPrimaryColumnsConcatString = fmt.Sprintf("MD5(%s)", allPrimaryColumnsConcatString)
+	}
+
 	return formatQuery(fmt.Sprintf(`
 			SELECT md5(CONCAT(starthash::TEXT, endhash::TEXT))
 			FROM (
@@ -216,7 +237,7 @@ func buildBookendHashQuery(config Config, schemaName, tableName string, columns 
 				FROM (
 					SELECT '' AS grouper, MD5(CONCAT(%s)) AS hash
 					FROM "%s"."%s"
-					ORDER BY CONCAT(%s) ASC
+					ORDER BY %s ASC
 					LIMIT %d
 				) AS eachrow
 				GROUP BY grouper
@@ -225,12 +246,12 @@ func buildBookendHashQuery(config Config, schemaName, tableName string, columns 
 				FROM (
 					SELECT '' AS grouper, MD5(CONCAT(%s)) AS hash
 					FROM "%s"."%s"
-					ORDER BY CONCAT(%s) DESC
+					ORDER BY %s DESC
 					LIMIT %d
 				) AS eachrow
 				GROUP BY grouper
 			) as endhash
-			`, allColumnsWithCasting, schemaName, tableName, allPrimaryColumnsWithCasting, limit, allColumnsWithCasting, schemaName, tableName, allPrimaryColumnsWithCasting, limit))
+			`, allColumnsWithCasting, schemaName, tableName, allPrimaryColumnsConcatString, limit, allColumnsWithCasting, schemaName, tableName, allPrimaryColumnsConcatString, limit))
 }
 
 // A minimal test that simply counts the number of rows.

--- a/query.go
+++ b/query.go
@@ -118,8 +118,7 @@ func buildFullHashQuery(config Config, schemaName, tableName string, columns []c
 
 	primaryColumnConcatString := fmt.Sprintf("CONCAT(%s)", primaryColumnString)
 
-	hashPKeys := true
-	if hashPKeys {
+	if config.HashPrimaryKeys {
 		primaryColumnConcatString = fmt.Sprintf("MD5(%s)", primaryColumnConcatString)
 	}
 
@@ -181,8 +180,7 @@ func buildSparseHashQuery(config Config, schemaName, tableName string, columns [
 
 	primaryColumnConcatString := fmt.Sprintf("CONCAT(%s)", primaryColumnString)
 
-	hashPKeys := true
-	if hashPKeys {
+	if config.HashPrimaryKeys {
 		primaryColumnConcatString = fmt.Sprintf("MD5(%s)", primaryColumnConcatString)
 	}
 
@@ -225,8 +223,7 @@ func buildBookendHashQuery(config Config, schemaName, tableName string, columns 
 
 	allPrimaryColumnsConcatString := fmt.Sprintf("CONCAT(%s)", allPrimaryColumnsWithCasting)
 
-	hashPKeys := true
-	if hashPKeys {
+	if config.HashPrimaryKeys {
 		allPrimaryColumnsConcatString = fmt.Sprintf("MD5(%s)", allPrimaryColumnsConcatString)
 	}
 

--- a/query_test.go
+++ b/query_test.go
@@ -75,6 +75,23 @@ func TestBuildFullHashQuery(t *testing.T) {
                 (SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash, CONCAT(content::TEXT, id::TEXT) as primary_key
                 FROM "testSchema"."testTable") AS eachrow GROUP BY grouper, primary_key ORDER BY primary_key`),
 		},
+		{
+			name:       "multi-column hashed primary key",
+			config:     Config{TimestampPrecision: TimestampPrecisionMilliseconds, HashPrimaryKeys: true},
+			schemaName: "testSchema",
+			tableName:  "testTable",
+			columns: []column{
+				{name: "id", dataType: "uuid", constraints: []string{"PRIMARY KEY", "another constraint"}},
+				{name: "content", dataType: "text", constraints: []string{"PRIMARY KEY"}},
+				{name: "when", dataType: "timestamp with time zone"},
+			},
+			primaryColumnNamesString: "id, content",
+			expectedQuery: formatQuery(`
+            SELECT md5(string_agg(hash, ''))
+            FROM
+                (SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash, MD5(CONCAT(content::TEXT, id::TEXT)) as primary_key
+                FROM "testSchema"."testTable") AS eachrow GROUP BY grouper, primary_key ORDER BY primary_key`),
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.expectedQuery, buildFullHashQuery(tc.config, tc.schemaName, tc.tableName, tc.columns))
@@ -106,12 +123,12 @@ func TestBuildSparseHashQuery(t *testing.T) {
             SELECT md5(string_agg(hash, ''))
             FROM
                 ( SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash, CONCAT(id::TEXT) as primary_key
-                FROM "testSchema"."testTable" 
-				WHERE id in ( 
-					SELECT id FROM "testSchema"."testTable" 
-					WHERE ('x' || substr(md5(CONCAT(id::TEXT)),1,16))::bit(64)::bigint % 10 = 0 ) 
+                FROM "testSchema"."testTable"
+				WHERE id in (
+					SELECT id FROM "testSchema"."testTable"
+					WHERE ('x' || substr(md5(CONCAT(id::TEXT)),1,16))::bit(64)::bigint % 10 = 0 )
 					ORDER BY CONCAT(id::TEXT)
-				) 
+				)
 				AS eachrow GROUP BY grouper, primary_key ORDER BY primary_key`),
 		},
 		{
@@ -128,12 +145,36 @@ func TestBuildSparseHashQuery(t *testing.T) {
             SELECT md5(string_agg(hash, ''))
             FROM
                 ( SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash, CONCAT(content::TEXT, id::TEXT) as primary_key
-                FROM "testSchema"."testTable" 
-				WHERE content in ( 
-					SELECT content FROM "testSchema"."testTable" 
+                FROM "testSchema"."testTable"
+				WHERE content in (
+					SELECT content FROM "testSchema"."testTable"
 					WHERE ('x' || substr(md5(CONCAT(content::TEXT, id::TEXT)),1,16))::bit(64)::bigint % 10 = 0
-				) AND id in ( 
-					SELECT id FROM "testSchema"."testTable" 
+				) AND id in (
+					SELECT id FROM "testSchema"."testTable"
+					WHERE ('x' || substr(md5(CONCAT(content::TEXT, id::TEXT)),1,16))::bit(64)::bigint % 10 = 0
+				) ORDER BY CONCAT(content::TEXT, id::TEXT) )
+				AS eachrow GROUP BY grouper, primary_key ORDER BY primary_key`),
+		},
+		{
+			name:       "multi-column hashed primary key",
+			config:     Config{TimestampPrecision: TimestampPrecisionMilliseconds, HashPrimaryKeys: true},
+			schemaName: "testSchema",
+			tableName:  "testTable",
+			columns: []column{
+				{name: "id", dataType: "uuid", constraints: []string{"PRIMARY KEY", "another constraint"}},
+				{name: "content", dataType: "text", constraints: []string{"PRIMARY KEY"}},
+				{name: "when", dataType: "timestamp with time zone"},
+			},
+			expectedQuery: formatQuery(`
+            SELECT md5(string_agg(hash, ''))
+            FROM
+                ( SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash, MD5(CONCAT(content::TEXT, id::TEXT)) as primary_key
+                FROM "testSchema"."testTable"
+				WHERE content in (
+					SELECT content FROM "testSchema"."testTable"
+					WHERE ('x' || substr(md5(CONCAT(content::TEXT, id::TEXT)),1,16))::bit(64)::bigint % 10 = 0
+				) AND id in (
+					SELECT id FROM "testSchema"."testTable"
 					WHERE ('x' || substr(md5(CONCAT(content::TEXT, id::TEXT)),1,16))::bit(64)::bigint % 10 = 0
 				) ORDER BY CONCAT(content::TEXT, id::TEXT) )
 				AS eachrow GROUP BY grouper, primary_key ORDER BY primary_key`),


### PR DESCRIPTION
[PIE-1100](https://udacity.atlassian.net/browse/PIE-1100)

## The problem

The initial attempt at migrating `ucheck-api/production` ([PIE-1031](https://udacity.atlassian.net/browse/PIE-1031)) failed at verification:

```
+--------+-----------------+----------------------------------+----------+--------+
| schema |      table      |               full               | rowcount | target |
+--------+-----------------+----------------------------------+----------+--------+
| public | api_tokens      | 079931596a3cf74855304969dda638dd |        3 | crdb   |
|        |                 | 079931596a3cf74855304969dda638dd |        3 | rds    |
|        | gorp_migrations | 559c474cffaf1bc32d7556a5fd9c8f01 |        5 | crdb   |
|        |                 | 559c474cffaf1bc32d7556a5fd9c8f01 |        5 | rds    |
|        | reports         | f9e2b6c11ba47ef9eb8afae77b9183b4 |   213569 | crdb   |
|        |                 | f9e2b6c11ba47ef9eb8afae77b9183b4 |   213569 | rds    |
|        | repos           | 1199ff8752ff162bd845a59c6988b2de |       92 | rds    |
|        |                 | 49b675c82e1e8ca71881f31078ee308e |       92 | crdb   |
+--------+-----------------+----------------------------------+----------+--------+
Error: public.repos test full has 2 outputs
```

The `public.repos` table uses the `name` of the repository as the `PRIMARY KEY`, of type `TEXT`. My investigation shows that the `ORDER BY` clause works differently on `TEXT` for `cockroachdb` compared to `postgres/rds`:

Output `diff` of `select name from repos order by name desc`:
```
27d26
< github.com/udacity/pa-test-service
29a29
> github.com/udacity/pa-test-service
92d91
< github.com/udacity/AdvancedAndroid_FCMServer
93a93
> github.com/udacity/AdvancedAndroid_FCMServer
```

Output `diff` of `select name from repos order by md5(name) desc`: `none`

## The fix

This PR adds the `--hash-primary-keys` option to `ORDER BY MD5(primary_key)` instead of `ORDER BY primary_key`. Running verification with this patched version shows no error:
```
+--------+-----------------+----------------------------------+----------+--------+
| schema |      table      |               full               | rowcount | target |
+--------+-----------------+----------------------------------+----------+--------+
| public | api_tokens      | 079931596a3cf74855304969dda638dd |        3 | crdb   |
|        |                 | 079931596a3cf74855304969dda638dd |        3 | rds    |
|        | gorp_migrations | 029e87a0dab4959bf25eeba473cab0fe |        5 | crdb   |
|        |                 | 029e87a0dab4959bf25eeba473cab0fe |        5 | rds    |
|        | reports         | 6f2b80de5b9485b411e01d5528cb004a |   213569 | crdb   |
|        |                 | 6f2b80de5b9485b411e01d5528cb004a |   213569 | rds    |
|        | repos           | 727d946761a48c303aae3fa1edb23ae9 |       92 | crdb   |
|        |                 | 727d946761a48c303aae3fa1edb23ae9 |       92 | rds    |
+--------+-----------------+----------------------------------+----------+--------+
```

[PIE-1031]: https://udacity.atlassian.net/browse/PIE-1031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PIE-1100]: https://udacity.atlassian.net/browse/PIE-1100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ