### PR TITLE
Check for race conditions, use numeric/decimal data types in test (PIE-1176)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ unit-test:
 
 .PHONY: test
 test:
-	go test -v -cover -coverprofile coverage.txt -covermode=atomic ./...
+	go test -v -cover -coverprofile coverage.txt -covermode=atomic -race ./...
 
 
 ################################################################################

--- a/integration_test.go
+++ b/integration_test.go
@@ -199,6 +199,8 @@ func TestVerifyData(t *testing.T) {
 		"bigint[]":         {"'{602213950000000000, -1}'"},
 		"integer":          {"0", "123979", "-23974"},
 		"double precision": {"69.123987", "-69.123987"},
+		"numeric":          {"0", "123.456", "-123.456"},
+		"decimal":          {"0", "123.456", "-123.456"},
 
 		"text":                  {`'foo'`, `'bar'`, `''`, `'something that is much longer but without much other complication'`},
 		"uuid":                  {fmt.Sprintf("'%s'", uuid.New().String())},


### PR DESCRIPTION
[PIE-1176](https://udacity.atlassian.net/browse/PIE-1176)


[PIE-1176]: https://udacity.atlassian.net/browse/PIE-1176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ