### PR TITLE
Fix GROUP BY string_agg bug

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -48,17 +48,17 @@ func waitForDBReady(t *testing.T, ctx context.Context, config *pgx.ConnConfig) b
 	return connected
 }
 
-func createContainer(t *testing.T, ctx context.Context, image string, port int, env, cmd []string) (string, int, error) {
+func createContainer(t *testing.T, ctx context.Context, image string, port int, env, cmd []string) (int, error) {
 	t.Helper()
 
 	docker, err := newDockerClient()
 	if err != nil {
-		return "", 0, err
+		return 0, err
 	}
 
 	hostPort, err := getFreePort()
 	if err != nil {
-		return "", 0, errors.New("could not determine a free port")
+		return 0, errors.New("could not determine a free port")
 	}
 
 	container, err := docker.runContainer(
@@ -76,7 +76,7 @@ func createContainer(t *testing.T, ctx context.Context, image string, port int, 
 			cmd: cmd,
 		})
 	if err != nil {
-		return "", 0, err
+		return 0, err
 	}
 
 	t.Cleanup(func() {
@@ -85,7 +85,7 @@ func createContainer(t *testing.T, ctx context.Context, image string, port int, 
 		}
 	})
 
-	return container.ID, hostPort, nil
+	return hostPort, nil
 }
 
 func calculateRowCount(columnTypes map[string][]string) int {
@@ -266,7 +266,7 @@ func TestVerifyData(t *testing.T) {
 	for _, db := range dbs {
 		aliases = append(aliases, db.image)
 		// Create db and connect
-		_, port, err := createContainer(t, ctx, db.image, db.port, db.env, db.cmd)
+		port, err := createContainer(t, ctx, db.image, db.port, db.env, db.cmd)
 		require.NoError(t, err)
 		config, err := pgx.ParseConfig(fmt.Sprintf("postgresql://%s@127.0.0.1:%d%s", db.userPassword, port, db.db))
 		require.NoError(t, err)
@@ -330,5 +330,104 @@ func TestVerifyData(t *testing.T) {
 		)
 		require.NoError(t, err)
 		results.WriteAsTable(os.Stdout)
+	}
+}
+
+func TestVerifyDataFail(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	// Arrange
+	ctx := context.Background()
+
+	dbs := []struct {
+		image        string
+		cmd          []string
+		env          []string
+		port         int
+		userPassword string
+		db           string
+	}{
+		{
+			image: "postgres:12.11",
+			cmd:   []string{"postgres"},
+			env: []string{
+				fmt.Sprintf("POSTGRES_DB=%s", dbName),
+				fmt.Sprintf("POSTGRES_USER=%s", dbUser),
+				fmt.Sprintf("POSTGRES_PASSWORD=%s", dbPassword),
+			},
+			port:         5432,
+			userPassword: dbUser + ":" + dbPassword,
+			db:           "/" + dbName,
+		},
+		{
+			image:        "cockroachdb/cockroach:latest", // cockroach cloud
+			cmd:          []string{"start-single-node", "--insecure"},
+			port:         26257,
+			userPassword: "root",
+		},
+	}
+
+	// Act
+	var targets []*pgx.ConnConfig
+
+	var aliases []string
+
+	var conns []*pgx.Conn
+
+	for _, db := range dbs {
+		// Create db and connect
+		port, err := createContainer(t, ctx, db.image, db.port, db.env, db.cmd)
+		require.NoError(t, err)
+		config, err := pgx.ParseConfig(fmt.Sprintf("postgresql://%s@127.0.0.1:%d%s", db.userPassword, port, db.db))
+		require.NoError(t, err)
+		assert.True(t, waitForDBReady(t, ctx, config))
+		conn, err := pgx.ConnectConfig(ctx, config)
+		require.NoError(t, err)
+
+		aliases = append(aliases, db.image)
+		conns = append(conns, conn)
+		targets = append(targets, config)
+
+		// Create tables, insert 1 for each to start
+		initTableQuery := `
+			create table failtest (id int primary key);
+			insert into failtest (id) values (5);
+		`
+		_, err = conn.Exec(ctx, initTableQuery)
+		require.NoError(t, err)
+	}
+
+	t.Cleanup(func() {
+		for _, conn := range conns {
+			conn.Close(ctx)
+		}
+	})
+
+	logger := logrus.New()
+	logger.Level = logrus.DebugLevel
+
+	for _, test := range []string{
+		pgverify.TestModeFull,
+		pgverify.TestModeSparse,
+		pgverify.TestModeBookend,
+		pgverify.TestModeRowCount,
+	} {
+		test := test
+		t.Run(test+"/AllSameRowPass", func(t *testing.T) {
+			results, err := pgverify.Verify(
+				ctx,
+				targets,
+				pgverify.WithTests(test),
+				pgverify.WithBookendLimit(1),
+				pgverify.WithSparseMod(1),
+				pgverify.WithLogger(logger),
+				pgverify.IncludeSchemas("public"),
+				pgverify.WithAliases(aliases),
+			)
+			results.WriteAsTable(os.Stdout)
+			require.NoError(t, err)
+		})
 	}
 }

--- a/query.go
+++ b/query.go
@@ -122,6 +122,8 @@ func buildFullHashQuery(config Config, schemaName, tableName string, columns []c
 		primaryColumnConcatString = fmt.Sprintf("MD5(%s)", primaryColumnConcatString)
 	}
 
+	// The 'GROUP BY grouper' with grouper as an empty string is causing only the
+	// first returned result to be passed to string_agg()
 	return formatQuery(fmt.Sprintf(`
 		SELECT md5(string_agg(hash, ''))
 		FROM (SELECT '' AS grouper, MD5(CONCAT(%s)) AS hash, %s as primary_key FROM "%s"."%s") AS eachrow
@@ -184,6 +186,7 @@ func buildSparseHashQuery(config Config, schemaName, tableName string, columns [
 		primaryColumnConcatString = fmt.Sprintf("MD5(%s)", primaryColumnConcatString)
 	}
 
+	// This falls into the same trap as the full test query
 	return formatQuery(fmt.Sprintf(`
 		SELECT md5(string_agg(hash, ''))
 		FROM (
@@ -227,6 +230,8 @@ func buildBookendHashQuery(config Config, schemaName, tableName string, columns 
 		allPrimaryColumnsConcatString = fmt.Sprintf("MD5(%s)", allPrimaryColumnsConcatString)
 	}
 
+	// This 'should' fail as well in our current implementation, but the
+	// --sparse-mod=1 spec is hiding the issue
 	return formatQuery(fmt.Sprintf(`
 			SELECT md5(CONCAT(starthash::TEXT, endhash::TEXT))
 			FROM (

--- a/query_test.go
+++ b/query_test.go
@@ -53,10 +53,12 @@ func TestBuildFullHashQuery(t *testing.T) {
 			},
 			primaryColumnNamesString: "id",
 			expectedQuery: formatQuery(`
-            SELECT md5(string_agg(hash, ''))
-            FROM
-                (SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash, CONCAT(id::TEXT) as primary_key
-                FROM "testSchema"."testTable") AS eachrow GROUP BY grouper, primary_key ORDER BY primary_key`),
+			SELECT md5(string_agg(hash, ''))
+			FROM (
+				SELECT MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash
+				FROM "testSchema"."testTable"
+				ORDER BY CONCAT(id::TEXT)
+			) as eachhash`),
 		},
 		{
 			name:       "multi-column primary key",
@@ -70,10 +72,12 @@ func TestBuildFullHashQuery(t *testing.T) {
 			},
 			primaryColumnNamesString: "id, content",
 			expectedQuery: formatQuery(`
-            SELECT md5(string_agg(hash, ''))
-            FROM
-                (SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash, CONCAT(content::TEXT, id::TEXT) as primary_key
-                FROM "testSchema"."testTable") AS eachrow GROUP BY grouper, primary_key ORDER BY primary_key`),
+			SELECT md5(string_agg(hash, ''))
+			FROM (
+				SELECT MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash
+				FROM "testSchema"."testTable"
+				ORDER BY CONCAT(content::TEXT, id::TEXT)
+			) as eachhash`),
 		},
 		{
 			name:       "multi-column hashed primary key",
@@ -87,10 +91,12 @@ func TestBuildFullHashQuery(t *testing.T) {
 			},
 			primaryColumnNamesString: "id, content",
 			expectedQuery: formatQuery(`
-            SELECT md5(string_agg(hash, ''))
-            FROM
-                (SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash, MD5(CONCAT(content::TEXT, id::TEXT)) as primary_key
-                FROM "testSchema"."testTable") AS eachrow GROUP BY grouper, primary_key ORDER BY primary_key`),
+			SELECT md5(string_agg(hash, ''))
+			FROM (
+				SELECT MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash
+				FROM "testSchema"."testTable"
+				ORDER BY MD5(CONCAT(content::TEXT, id::TEXT))
+			) as eachhash`),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -120,16 +126,17 @@ func TestBuildSparseHashQuery(t *testing.T) {
 				{name: "when", dataType: "timestamp with time zone"},
 			},
 			expectedQuery: formatQuery(`
-            SELECT md5(string_agg(hash, ''))
-            FROM
-                ( SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash, CONCAT(id::TEXT) as primary_key
-                FROM "testSchema"."testTable"
+			SELECT md5(string_agg(hash, ''))
+			FROM (
+				SELECT MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash
+				FROM "testSchema"."testTable"
 				WHERE id in (
-					SELECT id FROM "testSchema"."testTable"
-					WHERE ('x' || substr(md5(CONCAT(id::TEXT)),1,16))::bit(64)::bigint % 10 = 0 )
-					ORDER BY CONCAT(id::TEXT)
+					SELECT id
+					FROM "testSchema"."testTable"
+					WHERE ('x' || substr(md5(CONCAT(id::TEXT)),1,16))::bit(64)::bigint % 10 = 0
 				)
-				AS eachrow GROUP BY grouper, primary_key ORDER BY primary_key`),
+				ORDER BY CONCAT(id::TEXT)
+			) AS eachrow`),
 		},
 		{
 			name:       "multi-column primary key",
@@ -142,18 +149,20 @@ func TestBuildSparseHashQuery(t *testing.T) {
 				{name: "when", dataType: "timestamp with time zone"},
 			},
 			expectedQuery: formatQuery(`
-            SELECT md5(string_agg(hash, ''))
-            FROM
-                ( SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash, CONCAT(content::TEXT, id::TEXT) as primary_key
-                FROM "testSchema"."testTable"
+			SELECT md5(string_agg(hash, ''))
+			FROM (
+				SELECT MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash
+				FROM "testSchema"."testTable"
 				WHERE content in (
-					SELECT content FROM "testSchema"."testTable"
+					SELECT content
+					FROM "testSchema"."testTable"
 					WHERE ('x' || substr(md5(CONCAT(content::TEXT, id::TEXT)),1,16))::bit(64)::bigint % 10 = 0
 				) AND id in (
-					SELECT id FROM "testSchema"."testTable"
+					SELECT id
+					FROM "testSchema"."testTable"
 					WHERE ('x' || substr(md5(CONCAT(content::TEXT, id::TEXT)),1,16))::bit(64)::bigint % 10 = 0
-				) ORDER BY CONCAT(content::TEXT, id::TEXT) )
-				AS eachrow GROUP BY grouper, primary_key ORDER BY primary_key`),
+				) ORDER BY CONCAT(content::TEXT, id::TEXT)
+			) AS eachrow`),
 		},
 		{
 			name:       "multi-column hashed primary key",
@@ -166,18 +175,20 @@ func TestBuildSparseHashQuery(t *testing.T) {
 				{name: "when", dataType: "timestamp with time zone"},
 			},
 			expectedQuery: formatQuery(`
-            SELECT md5(string_agg(hash, ''))
-            FROM
-                ( SELECT '' AS grouper, MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash, MD5(CONCAT(content::TEXT, id::TEXT)) as primary_key
-                FROM "testSchema"."testTable"
+			SELECT md5(string_agg(hash, ''))
+			FROM (
+				SELECT MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash
+				FROM "testSchema"."testTable"
 				WHERE content in (
-					SELECT content FROM "testSchema"."testTable"
+					SELECT content
+					FROM "testSchema"."testTable"
 					WHERE ('x' || substr(md5(CONCAT(content::TEXT, id::TEXT)),1,16))::bit(64)::bigint % 10 = 0
 				) AND id in (
-					SELECT id FROM "testSchema"."testTable"
+					SELECT id
+					FROM "testSchema"."testTable"
 					WHERE ('x' || substr(md5(CONCAT(content::TEXT, id::TEXT)),1,16))::bit(64)::bigint % 10 = 0
-				) ORDER BY CONCAT(content::TEXT, id::TEXT) )
-				AS eachrow GROUP BY grouper, primary_key ORDER BY primary_key`),
+				) ORDER BY MD5(CONCAT(content::TEXT, id::TEXT))
+			) AS eachrow`),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Way back in #2, I introduced a query pattern using `GROUP BY`:
```
SELECT md5(string_agg(hash, ''))
FROM (
    SELECT
        '' AS grouper,
        MD5(CONCAT(col_1,col_2)) AS hash
    FROM test_table
    ORDER BY primary_key
) AS eachrow
GROUP BY grouper
```

(I don't remember precisely, but I believe that `GROUP BY` was introduced to translate table output into an array that `string_agg()` could take as input.)

With recent attempts to migrate `user-api/production`, I was seeing cases where `full` tests were matching but `rowcount` was not! Testing revealed that using `'' as grouper` for the `GROUP BY` clause **drops all but the first row returned**, so that tables with different rows would generate identical hashes **as long as the 'last' rows were equivalent**.

The fix is relatively simple:
```
SELECT md5(string_agg(hash, ''))
FROM (
    SELECT
        MD5(CONCAT(col_1,col_2)) AS hash
    FROM test_table
    ORDER BY primary_key
) AS eachrow
```

By dropping `GROUP BY` altogether, we can simply return an ordered list of hashes to `string_agg` from a single inner query.