### PR TITLE
Support keyword-named columns by quote-wrapping column names

### DIFF
--- a/column.go
+++ b/column.go
@@ -30,10 +30,10 @@ func (c column) CastToText(precision string) string {
 	switch strings.ToLower(c.dataType) {
 	case "timestamp with time zone":
 		// Truncating the epoch means that timestamps will be compared "to the second"; timestamps with ms/ns differences will be considered equal.
-		return fmt.Sprintf("(extract(epoch from date_trunc('%s', %s))::DECIMAL * 1000000)::BIGINT::TEXT", precision, c.name)
+		return fmt.Sprintf(`(extract(epoch from date_trunc('%s', "%s"))::DECIMAL * 1000000)::BIGINT::TEXT`, precision, c.name)
 	case "jsonb", "json":
-		return fmt.Sprintf("length(%s::TEXT)::TEXT", c.name)
+		return fmt.Sprintf(`length("%s"::TEXT)::TEXT`, c.name)
 	default:
-		return c.name + "::TEXT"
+		return fmt.Sprintf(`"%s"::TEXT`, c.name)
 	}
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -281,7 +281,9 @@ func TestVerifyData(t *testing.T) {
 			if tableName == "test_column_names" {
 				_, err = conn.Exec(ctx, `
 				CREATE TABLE test_column_names (
-					id INT PRIMARY KEY
+					id INT PRIMARY KEY,
+					"default" INT,
+					"order" INT
 				);`)
 				require.NoError(t, err, "Failed to initialize 'test_column_names' table")
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -235,7 +235,7 @@ func TestVerifyData(t *testing.T) {
 	sort.Strings(keysWithTypes)
 	sort.Strings(sortedTypes)
 
-	tableNames := []string{"testtable1", "testTABLE_multi_col_2", "testtable3", "test_stringkey_table4"}
+	tableNames := []string{"testtable1", "testTABLE_multi_col_2", "testtable3", "test_stringkey_table4", "test_column_names"}
 	createTableQueryBase := fmt.Sprintf("( id INT DEFAULT 0 NOT NULL, zid INT DEFAULT 0 NOT NULL, sid TEXT NOT NULL, ignored TIMESTAMP WITH TIME ZONE DEFAULT NOW(), %s);", strings.Join(keysWithTypes, ", "))
 
 	rowCount := calculateRowCount(columnTypes)
@@ -278,6 +278,16 @@ func TestVerifyData(t *testing.T) {
 
 		// Create and populate tables
 		for _, tableName := range tableNames {
+			if tableName == "test_column_names" {
+				_, err = conn.Exec(ctx, `
+				CREATE TABLE test_column_names (
+					id INT PRIMARY KEY
+				);`)
+				require.NoError(t, err, "Failed to initialize 'test_column_names' table")
+
+				continue // skip populating this table
+			}
+
 			createTableQuery := fmt.Sprintf(`CREATE TABLE "%s" %s`, tableName, createTableQueryBase)
 			_, err = conn.Exec(ctx, createTableQuery)
 			require.NoError(t, err, "Failed to create table %s on %v with query: %s", tableName, db.image, createTableQuery)

--- a/query_test.go
+++ b/query_test.go
@@ -55,9 +55,9 @@ func TestBuildFullHashQuery(t *testing.T) {
 			expectedQuery: formatQuery(`
 			SELECT md5(string_agg(hash, ''))
 			FROM (
-				SELECT MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash
+				SELECT MD5(CONCAT("content"::TEXT, "id"::TEXT, (extract(epoch from date_trunc('milliseconds', "when"))::DECIMAL * 1000000)::BIGINT::TEXT)) AS hash
 				FROM "testSchema"."testTable"
-				ORDER BY CONCAT(id::TEXT)
+				ORDER BY CONCAT("id"::TEXT)
 			) as eachhash`),
 		},
 		{
@@ -74,9 +74,9 @@ func TestBuildFullHashQuery(t *testing.T) {
 			expectedQuery: formatQuery(`
 			SELECT md5(string_agg(hash, ''))
 			FROM (
-				SELECT MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash
+				SELECT MD5(CONCAT("content"::TEXT, "id"::TEXT, (extract(epoch from date_trunc('milliseconds', "when"))::DECIMAL * 1000000)::BIGINT::TEXT)) AS hash
 				FROM "testSchema"."testTable"
-				ORDER BY CONCAT(content::TEXT, id::TEXT)
+				ORDER BY CONCAT("content"::TEXT, "id"::TEXT)
 			) as eachhash`),
 		},
 		{
@@ -93,9 +93,9 @@ func TestBuildFullHashQuery(t *testing.T) {
 			expectedQuery: formatQuery(`
 			SELECT md5(string_agg(hash, ''))
 			FROM (
-				SELECT MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash
+				SELECT MD5(CONCAT("content"::TEXT, "id"::TEXT, (extract(epoch from date_trunc('milliseconds', "when"))::DECIMAL * 1000000)::BIGINT::TEXT)) AS hash
 				FROM "testSchema"."testTable"
-				ORDER BY MD5(CONCAT(content::TEXT, id::TEXT))
+				ORDER BY MD5(CONCAT("content"::TEXT, "id"::TEXT))
 			) as eachhash`),
 		},
 	} {
@@ -128,14 +128,14 @@ func TestBuildSparseHashQuery(t *testing.T) {
 			expectedQuery: formatQuery(`
 			SELECT md5(string_agg(hash, ''))
 			FROM (
-				SELECT MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash
+				SELECT MD5(CONCAT("content"::TEXT, "id"::TEXT, (extract(epoch from date_trunc('milliseconds', "when"))::DECIMAL * 1000000)::BIGINT::TEXT)) AS hash
 				FROM "testSchema"."testTable"
 				WHERE id in (
 					SELECT id
 					FROM "testSchema"."testTable"
-					WHERE ('x' || substr(md5(CONCAT(id::TEXT)),1,16))::bit(64)::bigint % 10 = 0
+					WHERE ('x' || substr(md5(CONCAT("id"::TEXT)),1,16))::bit(64)::bigint % 10 = 0
 				)
-				ORDER BY CONCAT(id::TEXT)
+				ORDER BY CONCAT("id"::TEXT)
 			) AS eachrow`),
 		},
 		{
@@ -151,17 +151,17 @@ func TestBuildSparseHashQuery(t *testing.T) {
 			expectedQuery: formatQuery(`
 			SELECT md5(string_agg(hash, ''))
 			FROM (
-				SELECT MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash
+				SELECT MD5(CONCAT("content"::TEXT, "id"::TEXT, (extract(epoch from date_trunc('milliseconds', "when"))::DECIMAL * 1000000)::BIGINT::TEXT)) AS hash
 				FROM "testSchema"."testTable"
 				WHERE content in (
 					SELECT content
 					FROM "testSchema"."testTable"
-					WHERE ('x' || substr(md5(CONCAT(content::TEXT, id::TEXT)),1,16))::bit(64)::bigint % 10 = 0
+					WHERE ('x' || substr(md5(CONCAT("content"::TEXT, "id"::TEXT)),1,16))::bit(64)::bigint % 10 = 0
 				) AND id in (
 					SELECT id
 					FROM "testSchema"."testTable"
-					WHERE ('x' || substr(md5(CONCAT(content::TEXT, id::TEXT)),1,16))::bit(64)::bigint % 10 = 0
-				) ORDER BY CONCAT(content::TEXT, id::TEXT)
+					WHERE ('x' || substr(md5(CONCAT("content"::TEXT, "id"::TEXT)),1,16))::bit(64)::bigint % 10 = 0
+				) ORDER BY CONCAT("content"::TEXT, "id"::TEXT)
 			) AS eachrow`),
 		},
 		{
@@ -177,17 +177,17 @@ func TestBuildSparseHashQuery(t *testing.T) {
 			expectedQuery: formatQuery(`
 			SELECT md5(string_agg(hash, ''))
 			FROM (
-				SELECT MD5(CONCAT((extract(epoch from date_trunc('milliseconds', when))::DECIMAL * 1000000)::BIGINT::TEXT, content::TEXT, id::TEXT)) AS hash
+				SELECT MD5(CONCAT("content"::TEXT, "id"::TEXT, (extract(epoch from date_trunc('milliseconds', "when"))::DECIMAL * 1000000)::BIGINT::TEXT)) AS hash
 				FROM "testSchema"."testTable"
 				WHERE content in (
 					SELECT content
 					FROM "testSchema"."testTable"
-					WHERE ('x' || substr(md5(CONCAT(content::TEXT, id::TEXT)),1,16))::bit(64)::bigint % 10 = 0
+					WHERE ('x' || substr(md5(CONCAT("content"::TEXT, "id"::TEXT)),1,16))::bit(64)::bigint % 10 = 0
 				) AND id in (
 					SELECT id
 					FROM "testSchema"."testTable"
-					WHERE ('x' || substr(md5(CONCAT(content::TEXT, id::TEXT)),1,16))::bit(64)::bigint % 10 = 0
-				) ORDER BY MD5(CONCAT(content::TEXT, id::TEXT))
+					WHERE ('x' || substr(md5(CONCAT("content"::TEXT, "id"::TEXT)),1,16))::bit(64)::bigint % 10 = 0
+				) ORDER BY MD5(CONCAT("content"::TEXT, "id"::TEXT))
 			) AS eachrow`),
 		},
 	} {


### PR DESCRIPTION
Fixes an bug where columns that are also keywords (i.e. `default`, `order`) resulted in SQL errors for verification.

Sample log with SQL error without fix (from 889c03c test):
```
time="2024-07-08T18:51:11Z"
level=error msg=Query alias="cockroachdb/cockroach:v21.2.12"
err="ERROR: at or near \"order\": syntax error (SQLSTATE 42601)"
sql="SELECT md5(CONCAT(starthash::TEXT, endhash::TEXT)) FROM ( SELECT md5(string_agg(hash, '')) FROM ( SELECT MD5(CONCAT(default::TEXT, id::TEXT, order::TEXT)) AS hash FROM \"public\".\"test_column_names\" ORDER BY MD5(CONCAT(id::TEXT)) ASC LIMIT 5 ) AS eachrow ) as starthash, ( SELECT md5(string_agg(hash, '')) FROM ( SELECT MD5(CONCAT(default::TEXT, id::TEXT, order::TEXT)) AS hash FROM \"public\".\"test_column_names\" ORDER BY MD5(CONCAT(id::TEXT)) DESC LIMIT 5 ) AS eachrow ) as endhash"
```