### PR TITLE
fix: Ignore VIEWS

### DIFF
--- a/query.go
+++ b/query.go
@@ -20,7 +20,7 @@ func formatQuery(query string) string {
 // SQL 'WHERE' clause. Exclusions override inclusions.
 func buildGetTablesQuery(includeSchemas, excludeSchemas, includeTables, excludeTables []string) string {
 	query := "SELECT table_schema, table_name FROM information_schema.tables"
-	whereClauses := []string{}
+	whereClauses := []string{"table_type != 'VIEW'"}
 
 	if len(includeSchemas) > 0 {
 		whereClause := "table_schema IN ("

--- a/query_test.go
+++ b/query_test.go
@@ -20,7 +20,7 @@ func TestBuildGetTablesQuery(t *testing.T) {
 	}{
 		{
 			name:          "no filters",
-			expectedQuery: "SELECT table_schema, table_name FROM information_schema.tables",
+			expectedQuery: "SELECT table_schema, table_name FROM information_schema.tables WHERE table_type != 'VIEW'",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Since VIEWS cannot have primary keys, we need to explicitly avoid treating them as tables when gathering schema information.