### PR TITLE
Fix spacing-consistency with JSON length comparison

### DIFF
--- a/column.go
+++ b/column.go
@@ -31,7 +31,9 @@ func (c column) CastToText(precision string) string {
 	case "timestamp with time zone":
 		// Truncating the epoch means that timestamps will be compared "to the second"; timestamps with ms/ns differences will be considered equal.
 		return fmt.Sprintf(`(extract(epoch from date_trunc('%s', "%s"))::DECIMAL * 1000000)::BIGINT::TEXT`, precision, c.name)
-	case "jsonb", "json":
+	case "json":
+		return fmt.Sprintf(`length("%s"::JSONB::TEXT)::TEXT`, c.name)
+	case "jsonb":
 		return fmt.Sprintf(`length("%s"::TEXT)::TEXT`, c.name)
 	default:
 		return fmt.Sprintf(`"%s"::TEXT`, c.name)

--- a/integration_test.go
+++ b/integration_test.go
@@ -207,8 +207,8 @@ func TestVerifyData(t *testing.T) {
 		`character varying(64)`: {`'more string stuff'`},
 		"text[]":                {`'{"foo", "bar"}'`, `'{"baz", "qux"}'`, `'{"foo", "bar", "baz", "qux"}'`, `ARRAY[]::text[]`, `'{}'`},
 
-		"jsonb": {`'{}'`, `'{"foo": ["bar", "baz"]}'`, `'{"foo": "bar"}'`, `'{"foo": "bar", "baz": "qux"}'`, `'{"for sure?": true, "has numbers": 123.456, "this is": ["some", "json", "blob"]}'`},
-		"json":  {`'{}'`, `'{"foo": ["bar", "baz"]}'`, `'{"foo": "bar"}'`, `'{"foo": "bar", "baz": "qux"}'`, `'{"for sure?": true, "has numbers": 123.456, "this is": ["some", "json", "blob"]}'`},
+		"jsonb": {`'{}'`, `'{"foo":["bar","baz"]}'`, `'{"foo": "bar"}'`, `'{"foo": "bar", "baz": "qux"}'`, `'{"for sure?": true, "has numbers": 123.456, "this is": ["some", "json", "blob"]}'`},
+		"json":  {`'{}'`, `'{"foo":["bar","baz"]}'`, `'{"foo": "bar"}'`, `'{"foo": "bar", "baz": "qux"}'`, `'{"for sure?": true, "has numbers": 123.456, "this is": ["some", "json", "blob"]}'`},
 
 		"date":                        {`'2020-12-31'`},
 		"timestamp with time zone":    {`'2020-12-31 23:59:59 -8:00'`, `'2022-06-08 20:03:06.957223+00'`}, // hashes differently for psql/crdb, convert to epoch when hashing


### PR DESCRIPTION
When a `json` value is inserted in PSQL without `{"spacing":["between","values"]}`, it fails length comparison in CRDB which adds `{"spacing": ["between", "values"]}`. This PR converts `JSON::JSONB` to ensure consistent spacing before comparison.